### PR TITLE
impliedVolatility() fails to calc a .callPrice when mid <= 0.00001

### DIFF
--- a/mibian/__init__.py
+++ b/mibian/__init__.py
@@ -17,6 +17,8 @@ def impliedVolatility(className, args, target, high=500.0, low=0.0):
 	decimals = len(str(target).split('.')[1])		# Count decimals
 	for i in range(10000):	# To avoid infinite loops
 		mid = (high + low) / 2
+		if mid < 0.00001:
+			mid = 0.00001
 		estimate = eval(className)(args, volatility=mid, performance=True).callPrice
 		if round(estimate, decimals) == target: 
 			break


### PR DESCRIPTION
impliedVolatility() simply fails to calc a .callPrice when mid  happens to be <= 0.00001.

this assumes that it is better to function than have such an infinitesimal level of accuracy for the value of mid 
