### PR TITLE
Updated iv function

### DIFF
--- a/mibian/__init__.py
+++ b/mibian/__init__.py
@@ -16,8 +16,18 @@ def impliedVolatility(className, args, callPrice=None, putPrice=None, high=500.0
 	'''Returns the estimated implied volatility'''
 	if callPrice:
 		target = callPrice
+		restimate = eval(className)(args, volatility=high, performance=True).callPrice  
+		if restimate < target:
+			return high
+		if args[0]>args[1] + callPrice:
+			return 0.001            
 	if putPrice:
 		target = putPrice
+		restimate = eval(className)(args, volatility=high, performance=True).putPrice
+		if restimate < target:
+			return high
+		if args[1]>args[0] + putPrice:
+			return 0.001            
 	decimals = len(str(target).split('.')[1])		# Count decimals
 	for i in range(10000):	# To avoid infinite loops
 		mid = (high + low) / 2


### PR DESCRIPTION
Implied Volatility Calculation Time Improved for deep In The Money options and far Out of The Money option.

Case 1:
Deep in the money options are traded with negative time values sometimes.
Underlying Price > StrikePrice + CallPrice
ImplieadVloatility function loops 10000 times to return "Low" value.

Case 2:
Far Out of The Money options are traded with IV greater than 'High' value in function sometimes.
ImplieadVloatility function loops 10000 times to return "High" value.

Both these cases are addressed in this edit. This improves performance a lot.
